### PR TITLE
Update pom.xml to use vintage junit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,13 +32,19 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.5.2</version>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.10.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Fixed the not detected test error. It was due to a missing dependency statement in the pom.xml.
Also updated the versions of the dependencies.